### PR TITLE
Remove -Werror from AM_INIT_AUTOMAKE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_INIT([shok], [0.01], [http://shok.io])
 AC_CONFIG_AUX_DIR([build-aux])
 
-AM_INIT_AUTOMAKE([-Wall -Werror foreign])
+AM_INIT_AUTOMAKE([-Wall foreign])
 
 AC_PROG_CXX
 AC_PROG_LIBTOOL


### PR DESCRIPTION
Autoreconf will fail with -Werror (warnings about subdir-objects). After adding subdir-objects to AM_INIT_AUTOMAKE, make fails. Without both, make successfully builds.
